### PR TITLE
Feature: CBLR25-952: Update getcoblr pricing table (Stripe embed + marketing cleanup)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to `.env.development` and `.env.production` in this directory.
+# `gatsby-config.js` loads `.env.${NODE_ENV}` via dotenv.
+#
+# Only variables prefixed with GATSBY_ are inlined into the browser bundle
+# (see https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/#accessing-environment-variables-in-the-browser).
+
+# Stripe embeddable pricing table — Dashboard → Product catalog → Pricing tables → your table → Copy code
+GATSBY_STRIPE_PRICING_TABLE_ID=
+GATSBY_STRIPE_PUBLISHABLE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public
 
 # dotenv environment variable files
 .env*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@
   Gatsby Minimal Starter
 </h1>
 
+## Stripe pricing table embed
+
+The home and pricing pages render Stripe’s [embeddable pricing table](https://docs.stripe.com/payments/checkout/pricing-table) via `src/components/StripePricingTableSection.jsx`.
+
+**Local setup**
+
+1. Copy `.env.example` to `.env.development` (and `.env.production` when testing a production build).
+2. Set both variables from the embed code in the Stripe Dashboard (**Product catalog → Pricing tables** → your table → **Copy code**):
+   - `GATSBY_STRIPE_PRICING_TABLE_ID` — value of the `pricing-table-id` attribute (starts with `prctbl_`).
+   - `GATSBY_STRIPE_PUBLISHABLE_KEY` — your publishable key (`pk_live_…` or `pk_test_…`).
+
+Restart `gatsby develop` after changing env files. For hosted builds (e.g. Netlify), configure the same `GATSBY_*` variables in the host’s environment settings.
+
 ## 🚀 Quick start
 
 1.  **Create a Gatsby site.**

--- a/src/components/CoreFeatures.jsx
+++ b/src/components/CoreFeatures.jsx
@@ -95,11 +95,6 @@ const CoreFeatures = ({ className = "" }) => {
                   <div className="relative leading-[140%] font-semibold [text-shadow:0px_4px_4px_rgba(0,_0,_0,_0.25)]">
                     Business Reporting
                   </div>
-                  <div className="rounded-2xl bg-blanchedalmond-100 flex flex-row items-center justify-center py-0.5 px-2 whitespace-nowrap text-center text-xs text-darksalmon font-body">
-                    <div className="relative leading-[17px] inline-block max-w-full min-w-[73px]">
-                      Coming Soon
-                    </div>
-                  </div>
                 </div>
               </div>
               <div className="self-stretch relative leading-[140%] font-body text-dark-75">
@@ -194,11 +189,6 @@ const CoreFeatures = ({ className = "" }) => {
                     <GraphSVG width={40} height={40} />
                   </span>
                   <div className="self-stretch flex flex-col items-start justify-start gap-[8px]">
-                    <div className="rounded-2xl bg-blanchedalmond-100 flex flex-row items-center justify-center py-0.5 px-2 whitespace-nowrap text-center">
-                      <div className="relative text-xs text-darksalmon font-body leading-[17px] inline-block min-w-[73px]">
-                        Coming Soon
-                      </div>
-                    </div>
                     <div className="self-stretch relative leading-[140%] font-semibold">
                       Business Reporting
                     </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -59,32 +59,6 @@ const Header = ({ className = "" }) => {
                 support your growth with easy technology.
               </div>
             </div>
-            <form
-              onSubmit={handleSubmit}
-              className="w-[560px] flex flex-row flex-wrap items-start justify-start gap-[16px] max-w-full"
-            >
-              <div className="flex-1 rounded-md bg-white box-border flex flex-row items-center justify-start py-[11px] px-[23px] gap-[8px] min-w-[223px] max-w-full border-[1px] border-solid border-blue-gray-300">
-                <input
-                  className="w-full [border:none] [outline:none] font-body text-base bg-[transparent] h-[22px] flex-1 relative leading-[140%] text-dark-50 text-left inline-block min-w-[177px] p-0"
-                  placeholder="Enter your email"
-                  type="email"
-                  name="email"
-                  value={email}
-                  onChange={handleChange}
-                  required
-                />
-              </div>
-              <button
-                type="submit"
-                className="cursor-pointer py-[9px] px-[22px] bg-success rounded-md flex flex-row items-center justify-center border-[2px] border-solid border-seagreen"
-              >
-                <div className="flex flex-row items-center justify-center py-0 px-6">
-                  <div className="relative text-lg leading-[140%] font-semibold font-sub-title text-white text-left inline-block min-w-[105px] whitespace-nowrap">
-                    Get started
-                  </div>
-                </div>
-              </button>
-            </form>
           </div>
         </section>
       </div>
@@ -130,32 +104,6 @@ const Header = ({ className = "" }) => {
               support your growth with easy technology.
             </div>
           </div>
-          <form
-            onSubmit={handleSubmit}
-            className="self-stretch flex flex-row flex-wrap items-start justify-start gap-[8px]"
-          >
-            <div className="w-[195px] rounded-3xs bg-white box-border flex flex-row items-center justify-start py-[11px] px-6 gap-[8px] border-[1px] border-solid border-blue-gray-300">
-              <input
-                className="w-[87px] [border:none] [outline:none] font-body text-xs bg-[transparent] h-[17px] relative leading-[140%] text-dark-50 text-left inline-block p-0"
-                placeholder="Enter your email"
-                type="email"
-                name="email"
-                value={email}
-                onChange={handleChange}
-                required
-              />
-            </div>
-            <button
-              type="submit"
-              className="cursor-pointer p-2 bg-success flex-1 rounded-3xs box-border flex flex-row items-center justify-center min-w-[97px] border-[2px] border-solid border-seagreen"
-            >
-              <div className="flex flex-row items-center justify-center py-0 px-6">
-                <div className="relative text-base leading-[140%] font-body text-white text-left inline-block min-w-[81px] whitespace-nowrap">
-                  Get started
-                </div>
-              </div>
-            </button>
-          </form>
         </section>
       </div>
     </>

--- a/src/components/NavExpanded.jsx
+++ b/src/components/NavExpanded.jsx
@@ -1,4 +1,4 @@
-import { Link, navigate } from "gatsby";
+import { Link } from "gatsby";
 import * as React from "react";
 
 const NavExpanded = ({ expand = false }) => {
@@ -62,16 +62,6 @@ const NavExpanded = ({ expand = false }) => {
               Log In
             </div>
           </div>
-          <button className="cursor-pointer py-[9px] px-5 bg-success self-stretch shadow-[0px_1px_1.92px_rgba(16,_24,_40,_0.05)] rounded-sm overflow-hidden flex flex-row items-start justify-center whitespace-nowrap border-[1px] border-solid border-success">
-            <div
-              onClick={() =>
-                window.open(process.env.GATSBY_SIGNUP_URL, "_blank")
-              }
-              className="relative text-base leading-[140%] font-body text-white text-left inline-block min-w-[54px]"
-            >
-              Sign up
-            </div>
-          </button>
         </div>
       </section>
     </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import useFileImport from "../hooks/useFileImport";
 import NavExpanded from "./NavExpanded";
 import { CloseSVG } from "./icons";
-import { Link, navigate } from "gatsby";
+import { Link } from "gatsby";
 
 const Navbar = ({ className = "", currentPage }) => {
   const fileMap = useFileImport();
@@ -154,25 +154,13 @@ const Navbar = ({ className = "", currentPage }) => {
           </div>
         </div>
         <div className="flex flex-row items-center justify-start text-blue-gray-900 font-body">
-          <div className="flex flex-row items-center justify-start gap-[16px]">
-            <div
-              onClick={() =>
-                window.open(process.env.GATSBY_LOGIN_URL, "_blank")
-              }
-              className="cursor-pointer relative leading-[140%] inline-block min-w-[44px] whitespace-nowrap"
-            >
-              Log In
-            </div>
-            <button className="cursor-pointer py-[15px] px-[31px] bg-success shadow-[0px_1px_1.92px_rgba(16,_24,_40,_0.05)] rounded-[14px] overflow-hidden flex flex-row items-center justify-center whitespace-nowrap border-[1px] border-solid border-success hover:bg-mediumseagreen hover:box-border hover:border-[1px] hover:border-solid hover:border-mediumseagreen">
-              <div
-                onClick={() =>
-                  window.open(process.env.GATSBY_SIGNUP_URL, "_blank")
-                }
-                className="relative text-base leading-[140%] font-body text-white text-left inline-block min-w-[54px]"
-              >
-                Sign up
-              </div>
-            </button>
+          <div
+            onClick={() =>
+              window.open(process.env.GATSBY_LOGIN_URL, "_blank")
+            }
+            className="cursor-pointer relative leading-[140%] inline-block min-w-[44px] whitespace-nowrap"
+          >
+            Log In
           </div>
         </div>
       </div>

--- a/src/components/StripePricingTableSection.jsx
+++ b/src/components/StripePricingTableSection.jsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { Helmet } from "react-helmet";
+import SectionText from "./price-table/section-text";
+
+export const STRIPE_PRICING_TABLE_PROPS = {
+  "pricing-table-id": "prctbl_1Sv7lCAyFbkp4NXXdUmB3yIV",
+  "publishable-key":
+    "pk_live_51PIysTAyFbkp4NXXqtFhJS5ekLCM5XzgDgJz9O8DQnxJ4IorI9WhqQ7NUkN1YMyzlo8On7MXNCQCJeflzQ069byb00thRRmLsb",
+};
+
+const StripePricingTableSection = ({ title, subTitle }) => {
+  return (
+    <>
+      <Helmet>
+        <script async src="https://js.stripe.com/v3/pricing-table.js" />
+      </Helmet>
+      <div className="w-full flex flex-col items-center justify-start py-10 px-5 box-border gap-[60px] mq675:gap-[30px]">
+        <SectionText title={title} subTitle={subTitle} />
+        <div className="w-full self-stretch min-w-0">
+          <stripe-pricing-table
+            className="block w-full min-w-0"
+            {...STRIPE_PRICING_TABLE_PROPS}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default StripePricingTableSection;

--- a/src/components/StripePricingTableSection.jsx
+++ b/src/components/StripePricingTableSection.jsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { Helmet } from "react-helmet";
 import SectionText from "./price-table/section-text";
 
-export const STRIPE_PRICING_TABLE_PROPS = {
-  "pricing-table-id": "prctbl_1Sv7lCAyFbkp4NXXdUmB3yIV",
-  "publishable-key":
-    "pk_live_51PIysTAyFbkp4NXXqtFhJS5ekLCM5XzgDgJz9O8DQnxJ4IorI9WhqQ7NUkN1YMyzlo8On7MXNCQCJeflzQ069byb00thRRmLsb",
+/** Props for `<stripe-pricing-table />` (see `.env.example` and README). */
+const stripePricingTableProps = {
+  "pricing-table-id": process.env.GATSBY_STRIPE_PRICING_TABLE_ID ?? "",
+  "publishable-key": process.env.GATSBY_STRIPE_PUBLISHABLE_KEY ?? "",
 };
 
 const StripePricingTableSection = ({ title, subTitle }) => {
@@ -19,7 +19,7 @@ const StripePricingTableSection = ({ title, subTitle }) => {
         <div className="w-full self-stretch min-w-0">
           <stripe-pricing-table
             className="block w-full min-w-0"
-            {...STRIPE_PRICING_TABLE_PROPS}
+            {...stripePricingTableProps}
           />
         </div>
       </div>

--- a/src/components/StripePricingTableSection.jsx
+++ b/src/components/StripePricingTableSection.jsx
@@ -18,7 +18,7 @@ const StripePricingTableSection = ({ title, subTitle }) => {
         <SectionText title={title} subTitle={subTitle} />
         <div className="w-full self-stretch min-w-0">
           <stripe-pricing-table
-            className="block w-full min-w-0"
+            class="block w-full min-w-0"
             {...stripePricingTableProps}
           />
         </div>

--- a/src/components/features/frame-component.jsx
+++ b/src/components/features/frame-component.jsx
@@ -55,32 +55,6 @@ const FrameComponent = ({ className = "" }) => {
                   specifically for repair businesses.
                 </div>
               </div>
-              <form
-                onSubmit={handleSubmit}
-                className="w-[560px] flex flex-row flex-wrap items-start justify-start gap-[16px] max-w-full"
-              >
-                <div className="flex-1 rounded-md bg-white box-border flex flex-row items-center justify-start py-[11px] px-[23px] gap-[8px] min-w-[223px] max-w-full border-[1px] border-solid border-blue-gray-300">
-                  <input
-                    className="w-full [border:none] [outline:none] font-body text-base bg-[transparent] h-[22px] flex-1 relative leading-[140%] text-dark-50 text-left inline-block min-w-[177px] p-0"
-                    placeholder="Enter your email"
-                    type="email"
-                    name="email"
-                    value={email}
-                    onChange={handleChange}
-                    required
-                  />
-                </div>
-                <button
-                  type="submit"
-                  className="cursor-pointer py-[9px] px-[22px] bg-success rounded-md flex flex-row items-center justify-center border-[2px] border-solid border-seagreen"
-                >
-                  <div className="flex flex-row items-center justify-center py-0 px-6">
-                    <div className="relative text-lg leading-[140%] font-semibold font-sub-title text-white text-left inline-block min-w-[105px] whitespace-nowrap">
-                      Get started
-                    </div>
-                  </div>
-                </button>
-              </form>
             </div>
           </div>
         </div>
@@ -106,34 +80,6 @@ const FrameComponent = ({ className = "" }) => {
               specifically for repair businesses.
             </div>
           </div>
-          <form
-            onSubmit={handleSubmit}
-            className="self-stretch flex flex-row flex-wrap items-start justify-start gap-[8px] text-[12px] text-dark-50 font-body"
-          >
-            <div className="w-[195px] rounded-[10px] bg-white box-border flex flex-row items-center justify-start py-[11px] px-6 gap-[8px] border-[1px] border-solid border-blue-gray-300">
-              <div className="relative leading-[17px] inline-block min-w-[87px]">
-                <input
-                  className="relative leading-[17px] inline-block min-w-[87px]"
-                  placeholder="Enter your email"
-                  type="email"
-                  name="email"
-                  value={email}
-                  onChange={handleChange}
-                  required
-                />
-              </div>
-            </div>
-            <button
-              type="submit"
-              className="cursor-pointer py-2 px-[3px] bg-success flex-1 rounded-[10px] box-border flex flex-row items-center justify-center min-w-[90px] border-[2px] border-solid border-seagreen"
-            >
-              <div className="flex flex-row items-center justify-center py-0 px-6">
-                <div className="relative text-base leading-[140%] font-body text-white text-left inline-block min-w-[81px] whitespace-nowrap">
-                  Get started
-                </div>
-              </div>
-            </button>
-          </form>
         </section>
       </div>
     </>

--- a/src/components/support/FaqComponent.jsx
+++ b/src/components/support/FaqComponent.jsx
@@ -21,34 +21,6 @@ const FaqComponent = ({ className = "" }) => {
         Frequently Asked Questions
       </h2>
       <section className="self-stretch flex flex-col items-start justify-start max-w-full">
-        <FAQItem question="How does billing work?">
-          <p>
-            The Coblr subscription is charged on a monthly basis. After the 14
-            day free trial, your card will be charged for the next 30 days.
-          </p>
-          <p>
-            <b>For example)</b> If you are signed up for our Basic plan
-            ($50/month) and your free trial ends on the 14th of the month, you
-            will be charged $50 for the next month of access. Your billing date
-            will be the 15th of each month.
-          </p>
-          <p>
-            If you cancel before your billing date, you won’t be charged for the
-            upcoming month.
-          </p>
-          <p>
-            If you cancel after your billing date, we will refund you. We
-            promise. No funny business.
-          </p>
-        </FAQItem>
-        <FAQItem question="How do I add my employees?">
-          <p>
-            When you set up your account you have the ability to add new
-            employees. Note that all users can view all details on the app. We
-            will be launching permissions to tailor access for different user
-            types before Q4 2024.
-          </p>
-        </FAQItem>
         <FAQItem question="How to create a custom quote?">
           <p>
             You can create a full repair order in the POS and when you get to
@@ -84,12 +56,12 @@ const FaqComponent = ({ className = "" }) => {
           </ul>
           <p>You are now ready to create shipping labels in Coblr!</p>
         </FAQItem>
-        <FAQItem question="What automated emails are sent?">
+        <FAQItem question="What automated notifications are sent to my customers?">
           <p>
             We know that customers expect updates on their repairs to make the
             repair experience better. But doing this manually can be
             time-consuming. To improve the experience, we have built automated
-            email notifications throughout the entire Coblr product.
+             notifications throughout the entire Coblr product.
           </p>
           <ul className="list-disc">
             <li>
@@ -112,12 +84,6 @@ const FaqComponent = ({ className = "" }) => {
             update, but we suggest sending updates each time there is a change
             in status.
           </p>
-          <ul className="list-disc">
-            <li>
-              Customers will receive emails when you send them messages via our
-              app
-            </li>
-          </ul>
         </FAQItem>
         <FAQItem question="How do I request new features?">
           <p>
@@ -136,8 +102,7 @@ const FaqComponent = ({ className = "" }) => {
         <FAQItem question="How do I cancel?">
           <p>
             We hate to see you go! But, we are committed to making signing up
-            and canceling as easy as possible. To cancel, please email us at{" "}
-            <a href="mailto:info@getcoblr.com">info@getcoblr.com</a>
+            and canceling as easy as possible. You can cancel from the Billing section within the app.
           </p>
           <p>
             Of course, we would love to know why you are canceling. This helps
@@ -149,8 +114,8 @@ const FaqComponent = ({ className = "" }) => {
             Yes! Getting out the word to all shoe repair shops is so important!
             Please tell your referral to email us at{" "}
             <a href="mailto:referral@getcoblr.com">referral@getcoblr.com</a> and
-            copy your business email and we will offer both businesses 2 months
-            of free access to Coblr!
+            copy your business email and we will extend two months of Coblr
+            service to both businesses through our referral program.
           </p>
         </FAQItem>
         <FAQItem question="What platforms does Coblr work on?">

--- a/src/pages/features.js
+++ b/src/pages/features.js
@@ -4,7 +4,7 @@ import useFileImport from "../hooks/useFileImport";
 import { Rectangle1SVG, RectangleSVG } from "../components/icons";
 import Layout from "../components/Layout";
 import ImageText from "../components/ImageText";
-import TrailComponent from "../components/TrailComponent";
+import ContactForm from "../components/for-brand/contact-form";
 import SEO from "../components/seo";
 
 const FeaturesPage = () => {
@@ -60,7 +60,6 @@ const FeaturesPage = () => {
         <ImageText
           image={fileMap["report-1@2x"].gatsbyImageData}
           bottomImage={fileMap["reportaddon-1@2x"]}
-          comingSoon={true}
           title="Reporting"
           summaryList={[
             "View detailed insights on sales, customers, trends, and orders.",
@@ -68,6 +67,7 @@ const FeaturesPage = () => {
             "Download reports for your accountant.",
           ]}
         />
+        
         <div className="relative">
           <div
             style={{
@@ -78,8 +78,8 @@ const FeaturesPage = () => {
             }}
             className="[background:linear-gradient(97.2deg,_rgba(248,_255,_248,_0.01),_rgba(76,_140,_74,_0.05)),_#f7f7f7]"
           />
-          <TrailComponent />
         </div>
+        
       </div>
     </Layout>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,7 @@ import Header from "../components/Header";
 import CoreFeatures from "../components/CoreFeatures";
 import ImageText from "../components/ImageText";
 import useFileImport from "../hooks/useFileImport";
-import PriceTable from "../components/price-table";
+import StripePricingTableSection from "../components/StripePricingTableSection";
 import TrailComponent from "../components/TrailComponent";
 import SEO from "../components/seo";
 
@@ -37,12 +37,9 @@ const IndexPage = () => {
         title="Increase Revenue"
         summary="Reduce time spent on administrative tasks, grow repair volume, and improve the customer experience to keep customers coming back for repeat business."
       />
-      <PriceTable
+      <StripePricingTableSection
         title="Choose your plan"
-        subTitle={[
-          "Choose a plan that's right for your growing team.",
-          "Free for the first 14 days.",
-        ]}
+        subTitle={["Choose a plan that's right for your growing team"]}
       />
       <div className="relative">
         <div
@@ -55,7 +52,7 @@ const IndexPage = () => {
           }}
           className="[background:linear-gradient(97.2deg,_rgba(248,_255,_248,_0.01),_rgba(76,_140,_74,_0.05)),_#f7f7f7]"
         />
-        <TrailComponent />
+        
       </div>
     </Layout>
   );

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Layout from "../components/Layout";
-import PriceTable from "../components/price-table/index";
+import StripePricingTableSection from "../components/StripePricingTableSection";
 import FaqComponent from "../components/support/FaqComponent";
 import TrailComponent from "../components/TrailComponent";
 import SEO from "../components/seo";
@@ -8,12 +8,10 @@ import SEO from "../components/seo";
 const PricingPage = () => {
   return (
     <Layout currentPage="pricing" bg={true}>
-      <PriceTable
-        extended={true}
+      <StripePricingTableSection
         title="Choose a Plan to Grow Your Business"
         subTitle={[
           "Choose From One Of The Plans That Suits Your Business Best.",
-          "Free for the first 14 days.",
         ]}
       />
       <FaqComponent />
@@ -28,7 +26,7 @@ const PricingPage = () => {
           }}
           className="[background:linear-gradient(97.2deg,_rgba(248,_255,_248,_0.01),_rgba(76,_140,_74,_0.05)),_#f7f7f7]"
         />
-        <TrailComponent />
+        
       </div>
     </Layout>
   );

--- a/src/pages/support.js
+++ b/src/pages/support.js
@@ -21,7 +21,6 @@ const SupportPage = () => {
           }}
           className="[background:linear-gradient(97.2deg,_rgba(248,_255,_248,_0.01),_rgba(76,_140,_74,_0.05)),_#f7f7f7]"
         />
-        <TrailComponent />
       </div>
     </Layout>
   );


### PR DESCRIPTION

**Feature: CBLR25-952: Update getcoblr pricing table (Stripe embed + marketing cleanup)**
## Description

- **Stripe embeddable pricing table:** Adds `StripePricingTableSection.jsx`, which loads `https://js.stripe.com/v3/pricing-table.js` via `react-helmet`, reuses existing `SectionText` for headings, and renders the `<stripe-pricing-table>` web component with full-width layout (`self-stretch`, `min-w-0`) so plans display correctly.
- **Home & pricing:** Replaces the legacy `PriceTable` on **index** and **pricing** with `StripePricingTableSection`. Drops the extra subtitle line about “Free for the first 14 days” on both pages.
- **CTA / signup:** Removes the **Sign up** button from desktop (`Navbar.jsx`) and mobile drawer (`NavExpanded.jsx`). Removes email + **Get started** hero forms from **`Header.jsx`** and **`features/frame-component.jsx`**.
- **Trail CTA block:** Removes `<TrailComponent />` from **index**, **pricing**, **support**, and **features** (features page also drops `TrailComponent` import; adds `ContactForm` import per branch—verify that `ContactForm` is rendered if the branch should show a form).
- **Features:** Removes `comingSoon` on the Reporting `ImageText` block.
- **Support FAQ (`FaqComponent.jsx`):** Removes FAQ items “How does billing work?” and “How do I add my employees?”; renames “What automated emails are sent?” to “What automated notifications are sent to my customers?” and adjusts copy; removes a bullet about customer emails; updates cancel copy to in-app Billing; softens referral copy.

## Related Issue

[CBLR25-952](https://coblr.atlassian.net/browse/CBLR25-952) 

## Motivation and Context

Align getcoblr.com pricing with Stripe’s hosted/embeddable pricing table, reduce outdated trial/billing FAQ and duplicate signup CTAs, and simplify navigation toward Log In / Stripe checkout flows.

## How Has This Been Tested?

- [ ] `gatsby develop` / production build: home and `/pricing` render Stripe pricing table, script loads, layout is horizontal at desktop widths.
- [ ] Mobile: nav drawer has no Sign up; hero areas no longer show removed forms.
- [ ] `/support`: FAQ reads correctly; removed sections gone.
- [ ] `/features`: Reporting has no coming-soon pill; bottom section matches intent (Trail vs contact form).

*(Fill in what you actually ran.)*

## Screenshots (if appropriate):
<img width="1847" height="1105" alt="Screenshot 2026-04-18 at 3 06 55 PM" src="https://github.com/user-attachments/assets/18708070-afd3-4477-bae1-466c6fe43dfb" />

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes) — *partial: CTA/FAQ removals*
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

[CBLR25-952]: https://coblr.atlassian.net/browse/CBLR25-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the pricing/purchase entry point to a Stripe-loaded web component and relies on new `GATSBY_*` env vars; misconfiguration or script/embed issues could break pricing display or conversion flow.
> 
> **Overview**
> **Pricing now uses Stripe’s embeddable pricing table.** Adds `StripePricingTableSection.jsx` which injects Stripe’s `pricing-table.js` and renders `<stripe-pricing-table>` using `GATSBY_STRIPE_PRICING_TABLE_ID`/`GATSBY_STRIPE_PUBLISHABLE_KEY`; `index` and `/pricing` swap from the legacy `PriceTable` to this new section (and remove the “Free for the first 14 days” subtitle line).
> 
> **Marketing cleanup/removals.** Removes the hero email “Get started” forms, removes the “Sign up” CTA from both desktop navbar and mobile drawer (leaving only “Log In”), drops several `TrailComponent` placements, removes “Coming Soon” labeling around Reporting, and trims/updates `/support` FAQ content and wording. Adds `.env.example` (and un-ignores it) plus README setup instructions for the new Stripe env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82081f65f74bbe62c71cc473137fe7f645e40b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->